### PR TITLE
Fixed pagination

### DIFF
--- a/fakturoid/api.py
+++ b/fakturoid/api.py
@@ -10,7 +10,7 @@ from fakturoid.paging import ModelList
 
 __all__ = ['Fakturoid']
 
-link_header_pattern = re.compile('page=(\d+)>; rel="last"')
+link_header_pattern = re.compile(r'page=(\d+)[^>]*>; rel="last"')
 
 
 class Fakturoid(object):


### PR DESCRIPTION
This works:

```python
for invoice in fakturoid.invoices():
    ...
```

while this doesn't:

```python
for invoice in fakturoid.invoices(status='done', since=today):
    ...
```

The PR fixes the second case.