### PR TITLE
Add ability to search subjects by custom_id

### DIFF
--- a/fakturoid/api.py
+++ b/fakturoid/api.py
@@ -198,12 +198,14 @@ class SubjectsApi(CrudModelApi):
     model_type = Subject
     endpoint = 'subjects'
 
-    def find(self, since=None):
+    def find(self, since=None, custom_id=None):
         params = {}
         if since:
             if not isinstance(since, (datetime, date)):
                 raise TypeError("'since' parameter must be date or datetime")
             params['since'] = since.isoformat()
+        if custom_id:
+            params['custom_id'] = custom_id
         return super(SubjectsApi, self).find(params)
 
 


### PR DESCRIPTION
Adds `custom_id` parameter to `SubjectsApi.find()` method to allow searching subjects by their ID in external system (see [https://fakturoid.docs.apiary.io/reference/subjects/subjects-collection/seznam-vsech-kontaktu](https://fakturoid.docs.apiary.io/reference/subjects/subjects-collection/seznam-vsech-kontaktu)).